### PR TITLE
curses_client: add -I$(top_srcdir)/src/src

### DIFF
--- a/src/curses_client/Makefile.am
+++ b/src/curses_client/Makefile.am
@@ -1,4 +1,4 @@
 noinst_LIBRARIES = libcursesclient.a
 libcursesclient_a_SOURCES = curses_client.c curses_client.h
-AM_CPPFLAGS= -I${srcdir} @GLIB_CFLAGS@
+AM_CPPFLAGS= -I${srcdir} -I$(top_srcdir)/src @GLIB_CFLAGS@
 DEFS       = @DEFS@


### PR DESCRIPTION
Hi,

Currently when doing an out of source build it fails due to curses_client not finding configfile.h.

One way to fix it is to add `-I$(top_srcdir)/src` to curses_client's Makefile.am as suggested by this PR, but maybe there i a better way to fix it.

The full error I am seeing is:
```
[...]
dopewars has been configured as follows:

Building Unix version

CLIENTS
 - Text-mode (curses) client

TCP/IP networking support enabled for multi-player games

SERVER
 - Text-mode server

Making all in src
make[1]: Entering directory '/home/builder/.termux-build/dopewars/build/src'
make  all-recursive
make[2]: Entering directory '/home/builder/.termux-build/dopewars/build/src'
Making all in curses_client
make[3]: Entering directory '/home/builder/.termux-build/dopewars/build/src/curses_client'
aarch64-linux-android-clang -DHAVE_CONFIG_H -I. -I/home/builder/.termux-build/dopewars/src/src/curses_client -I../../src  -I/home/builder/.termux-build/dopewars/src/src/curses_client -I/data/data/com.termux/files/usr/include/glib-2.0 -I/data/data/com.termux/files/usr/lib/glib-2.0/include -I/data/data/com.termux/files/usr/include -I/data/data/com.termux/files/usr/include  -fstack-protector-strong -Oz -Wall -c -o curses_client.o /home/builder/.termux-build/dopewars/src/src/curses_client/curses_client.c
/home/builder/.termux-build/dopewars/src/src/curses_client/curses_client.c:37:10: fatal error: 'configfile.h' file not found
#include "configfile.h"
         ^~~~~~~~~~~~~~
1 error generated.
make[3]: *** [Makefile:428: curses_client.o] Error 1
make[3]: Leaving directory '/home/builder/.termux-build/dopewars/build/src/curses_client'
make[2]: *** [Makefile:652: all-recursive] Error 1
make[2]: Leaving directory '/home/builder/.termux-build/dopewars/build/src'
make[1]: *** [Makefile:467: all] Error 2
make[1]: Leaving directory '/home/builder/.termux-build/dopewars/build/src'
make: *** [Makefile:471: all-recursive] Error 1
```