### PR TITLE
Added detection of ncursesw and tinfo libs

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -158,20 +158,27 @@ else
 
    dnl On true Unix systems, test for valid curses-like libraries
    if test "$CURSES_CLIENT" != "no" ; then
-      AC_CHECK_LIB(ncurses,newterm)
-      if test "$ac_cv_lib_ncurses_newterm" = "no" ; then
-         AC_CHECK_LIB(curses,newterm)
-         if test "$ac_cv_lib_curses_newterm" = "no" ; then
-            AC_CHECK_LIB(cur_colr,newterm)
-            if test "$ac_cv_lib_cur_colr_newterm" = "no" ; then
-               if test "$CURSES_CLIENT" = "yes" ; then
-                 AC_MSG_ERROR(Cannot find any curses-type library)
-               else
-                 AC_MSG_WARN(Cannot find any curses-type library)
-                 CURSES_CLIENT="no"
+      AC_CHECK_LIB(ncursesw,newterm)
+      if test "$ac_cv_lib_ncursesw_newterm" = "no" ; then
+         AC_CHECK_LIB(ncurses,newterm)
+         if test "$ac_cv_lib_ncurses_newterm" = "no" ; then
+            AC_CHECK_LIB(curses,newterm)
+            if test "$ac_cv_lib_curses_newterm" = "no" ; then
+               AC_CHECK_LIB(cur_colr,newterm)
+               if test "$ac_cv_lib_cur_colr_newterm" = "no" ; then
+                  if test "$CURSES_CLIENT" = "yes" ; then
+                     AC_MSG_ERROR(Cannot find any curses-type library)
+                  else
+                     AC_MSG_WARN(Cannot find any curses-type library)
+                     CURSES_CLIENT="no"
+                  fi
                fi
             fi
+         else
+            AC_CHECK_LIB(tinfo,cbreak)
          fi
+      else
+         AC_CHECK_LIB(tinfow,cbreak)
       fi
    fi
 

--- a/src/cursesport/cursesport.h
+++ b/src/cursesport/cursesport.h
@@ -95,7 +95,7 @@ void endwin(void);
 #include <errno.h>
 
 /* Include a suitable curses-type library */
-#if HAVE_LIBNCURSES || defined(CURSES_HAVE_NCURSES_H)
+#if HAVE_LIBNCURSESW || HAVE_LIBNCURSES || defined(CURSES_HAVE_NCURSES_H)
 #include <ncurses.h>
 #elif HAVE_LIBCURSES || defined(CURSES_HAVE_CURSES_H)
 #include <curses.h>


### PR DESCRIPTION
Fixes wide-character display in curses client when wide-character (e.g. UTF-8) locale is used.

Fixes compilation on Gentoo, where linking with `-lncurses -ltinfo` (or wide-char variantes `-lncursesw -ltinfow`) is required.

Closes #71.

I also found a specific macro [AX_WITH_CURSES](https://www.gnu.org/software/autoconf-archive/ax_with_curses.html), and that seems to promise proper curses detection on a variety of platforms, but replacing `AC_CHECK_LIB` with it was not straightforward.