### PR TITLE
Restored check for curses_colr header

### DIFF
--- a/src/cursesport/cursesport.h
+++ b/src/cursesport/cursesport.h
@@ -105,8 +105,8 @@ void endwin(void);
 #  include <ncurses.h>
 #elif defined HAVE_CURSES_H
 #  include <curses.h>
-#else
-#  error "SysV or X/Open-compatible Curses header file required"
+#elif HAVE_LIBCUR_COLR
+#  include <curses_colr/curses.h>
 #endif
 
 #endif /* CYGWIN */


### PR DESCRIPTION
Follow up PR for issue #71, to make sure `cur_colr` lib detection is not inadvertently broken.

After this one is merged it should at least work the same as before, although I have no way of testing with this particular Curses variant.