### PR TITLE
Fix typo: Columbia -> Colombia

### DIFF
--- a/po/de.po
+++ b/po/de.po
@@ -791,7 +791,7 @@ msgstr "Weed"
 
 #: src/dopewars.c:732
 msgid ""
-"Columbian freighter dusted the Coast Guard! Weed prices have bottomed out!"
+"Colombian freighter dusted the Coast Guard! Weed prices have bottomed out!"
 msgstr ""
 "Ein kolumbianischer Frachter hat die Küstenwache umschippert. Der Preis für "
 "Weed ist ins bodenlose gefallen!"

--- a/po/dopewars.pot
+++ b/po/dopewars.pot
@@ -780,7 +780,7 @@ msgstr ""
 
 #: src/dopewars.c:732
 msgid ""
-"Columbian freighter dusted the Coast Guard! Weed prices have bottomed out!"
+"Colombian freighter dusted the Coast Guard! Weed prices have bottomed out!"
 msgstr ""
 
 #. The names of the default locations

--- a/po/en_GB.po
+++ b/po/en_GB.po
@@ -778,7 +778,7 @@ msgstr ""
 
 #: src/dopewars.c:732
 msgid ""
-"Columbian freighter dusted the Coast Guard! Weed prices have bottomed out!"
+"Colombian freighter dusted the Coast Guard! Weed prices have bottomed out!"
 msgstr ""
 
 #. The names of the default locations

--- a/po/es.po
+++ b/po/es.po
@@ -798,7 +798,7 @@ msgstr "Marihuana"
 
 #: src/dopewars.c:732
 msgid ""
-"Columbian freighter dusted the Coast Guard! Weed prices have bottomed out!"
+"Colombian freighter dusted the Coast Guard! Weed prices have bottomed out!"
 msgstr "Ha llegado la cosecha. ¡El precio de la marihuana está por los suelos!"
 
 #. The names of the default locations

--- a/po/es_ES.po
+++ b/po/es_ES.po
@@ -798,7 +798,7 @@ msgstr "María"
 
 #: src/dopewars.c:732
 msgid ""
-"Columbian freighter dusted the Coast Guard! Weed prices have bottomed out!"
+"Colombian freighter dusted the Coast Guard! Weed prices have bottomed out!"
 msgstr "Ha llegado la cosecha. ¡El precio de la marihuana está por los suelos!"
 
 #. The names of the default locations

--- a/po/fr.po
+++ b/po/fr.po
@@ -781,7 +781,7 @@ msgstr "Skunk"
 
 #: src/dopewars.c:732
 msgid ""
-"Columbian freighter dusted the Coast Guard! Weed prices have bottomed out!"
+"Colombian freighter dusted the Coast Guard! Weed prices have bottomed out!"
 msgstr "de la bonne herbe d'Amsterdam vient d'arriver en masse"
 
 #. The names of the default locations

--- a/po/fr_CA.po
+++ b/po/fr_CA.po
@@ -787,7 +787,7 @@ msgstr "Pot"
 
 #: src/dopewars.c:732
 msgid ""
-"Columbian freighter dusted the Coast Guard! Weed prices have bottomed out!"
+"Colombian freighter dusted the Coast Guard! Weed prices have bottomed out!"
 msgstr ""
 "Les récoltes des serres hydroponiques dépassent les attentes, c'est le temps "
 "de fumer!"

--- a/po/nn.po
+++ b/po/nn.po
@@ -794,8 +794,8 @@ msgstr "Jazztobakk"
 
 #: src/dopewars.c:732
 msgid ""
-"Columbian freighter dusted the Coast Guard! Weed prices have bottomed out!"
-msgstr "Columbiansk lasteskip lurte kystvakta! Jazztobakkprisen stuper!"
+"Colombian freighter dusted the Coast Guard! Weed prices have bottomed out!"
+msgstr "Colombiansk lasteskip lurte kystvakta! Jazztobakkprisen stuper!"
 
 #. The names of the default locations
 #: src/dopewars.c:740

--- a/po/pl.po
+++ b/po/pl.po
@@ -779,7 +779,7 @@ msgstr "Marihuana"
 
 #: src/dopewars.c:732
 msgid ""
-"Columbian freighter dusted the Coast Guard! Weed prices have bottomed out!"
+"Colombian freighter dusted the Coast Guard! Weed prices have bottomed out!"
 msgstr "Świeża dostawa marihuany z Holandii! Ceny trawy lecą w dół"
 
 #. The names of the default locations

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -781,7 +781,7 @@ msgstr "Maconha"
 
 #: src/dopewars.c:732
 msgid ""
-"Columbian freighter dusted the Coast Guard! Weed prices have bottomed out!"
+"Colombian freighter dusted the Coast Guard! Weed prices have bottomed out!"
 msgstr "Colombianos enganaram a Guarda Costeira! Preços de maconha abaixaram!"
 
 #. The names of the default locations

--- a/src/dopewars.c
+++ b/src/dopewars.c
@@ -729,7 +729,7 @@ struct DRUG DefaultDrug[] = {
   {N_("Shrooms"), 630, 1300, FALSE, FALSE, ""},
   {N_("Speed"), 90, 250, FALSE, TRUE, ""},
   {N_("Weed"), 315, 890, TRUE, FALSE,
-   N_("Columbian freighter dusted the Coast Guard! "
+   N_("Colombian freighter dusted the Coast Guard! "
       "Weed prices have bottomed out!")}
 };
 


### PR DESCRIPTION
[Colombia (the country)](https://en.wikipedia.org/wiki/Colombia) has no `U`s. Its spelling is often mistaken for [Columbia (symbol for the USA)](https://en.wikipedia.org/wiki/Columbia_(personification)).