### PR TITLE
Use xdg state home Closes #77

### DIFF
--- a/src/dopewars.c
+++ b/src/dopewars.c
@@ -2392,12 +2392,13 @@ gchar *GetLocalConfigFile(void)
 
   /* Local config changes are in the user's state directory */
   home = getenv("XDG_STATE_HOME");
-  if (!home) {
-  /* Local config is in the user's home directory */
-    home = getenv("HOME");
-  }
   if (home) {
-    conf = g_strdup_printf("%s/.dopewars", home);
+    conf = g_strdup_printf("%s/dopewars", home);
+  } else {
+    home = getenv("HOME");
+    if (home) {
+      conf = g_strdup_printf("%s/.local/state/dopewars", home);
+    }
   }
   return conf;
 #endif

--- a/src/dopewars.c
+++ b/src/dopewars.c
@@ -2390,8 +2390,12 @@ gchar *GetLocalConfigFile(void)
 #else
   gchar *home, *conf = NULL;
 
+  /* Local config changes are in the user's state directory */
+  home = getenv("XDG_STATE_HOME");
+  if (!home) {
   /* Local config is in the user's home directory */
-  home = getenv("HOME");
+    home = getenv("HOME");
+  }
   if (home) {
     conf = g_strdup_printf("%s/.dopewars", home);
   }


### PR DESCRIPTION
As discussed, this enables users to store custom configurations in any location (e.g, XDG_CONFIG_HOME). Use them with the `--config-file` option if so desired. Any changes made via the options menu are saved in the state directory. (Closes #77)

Notes:

- If the state directory does not exist, configuration changes will still take effect for the current session, but will not be written to a file. In this case, the user will receive a notification that the target file could not be opened.
- Existing users can continue using their `~/.dopewars` config files with the `--config-file` option or move them to the state directory.
- If a config file is moved to the state directory, any changes made via the options menu will overwrite it. Alternatively, users may move use it as a custom file in any location they prefer.